### PR TITLE
Removed undetected metadata dialect options

### DIFF
--- a/examples/worldbank.rs
+++ b/examples/worldbank.rs
@@ -3,7 +3,6 @@ extern crate csv_sniffer;
 
 use std::path::Path;
 
-use csv::Terminator;
 use csv_sniffer::metadata::*;
 
 fn main() {
@@ -18,10 +17,6 @@ fn main() {
             num_preamble_rows: 4,
         },
         quote: Quote::Some(b'"'),
-        doublequote_escapes: true,
-        comment: Comment::Disabled,
-        escape: Escape::Disabled,
-        terminator: Terminator::CRLF,
         flexible: false,
     };
     let mut reader = dialect.open_path(data_filepath).unwrap();

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
-use csv::{self, Reader, StringRecord, Terminator};
+use csv::{self, Reader, StringRecord};
 use csv_core as csvc;
 use regex::Regex;
 
@@ -128,11 +128,7 @@ impl Sniffer {
                     num_preamble_rows: self.num_preamble_rows.unwrap(),
                     has_header_row: self.has_header_row.unwrap(),
                 },
-                terminator: Terminator::CRLF,
                 quote: self.quote.clone().unwrap(),
-                doublequote_escapes: true,
-                escape: Escape::Disabled,
-                comment: Comment::Disabled,
                 flexible: self.flexible.unwrap(),
             },
             num_fields: self.delimiter_freq.unwrap() + 1,

--- a/tests/delimiter.rs
+++ b/tests/delimiter.rs
@@ -3,7 +3,6 @@ extern crate csv_sniffer;
 
 use std::path::Path;
 
-use csv::Terminator;
 use csv_sniffer::metadata::*;
 use csv_sniffer::{SampleSize, Sniffer, Type};
 
@@ -26,11 +25,7 @@ fn test_semicolon() {
                     has_header_row: true,
                     num_preamble_rows: 0,
                 },
-                terminator: Terminator::CRLF,
                 quote: Quote::None,
-                doublequote_escapes: true,
-                escape: Escape::Disabled,
-                comment: Comment::Disabled,
                 flexible: false
             },
             num_fields: 5,
@@ -64,11 +59,7 @@ fn test_comma() {
                     has_header_row: true,
                     num_preamble_rows: 0,
                 },
-                terminator: Terminator::CRLF,
                 quote: Quote::None,
-                doublequote_escapes: true,
-                escape: Escape::Disabled,
-                comment: Comment::Disabled,
                 flexible: false
             },
             num_fields: 5,
@@ -102,11 +93,7 @@ fn test_flexible() {
                     has_header_row: true,
                     num_preamble_rows: 0,
                 },
-                terminator: Terminator::CRLF,
                 quote: Quote::None,
-                doublequote_escapes: true,
-                escape: Escape::Disabled,
-                comment: Comment::Disabled,
                 flexible: true
             },
             num_fields: 7,


### PR DESCRIPTION
Since we aren't yet detecting some dialect options (quotation escaping, line terminators, and comment characters), it's misleading to include them in our returned metadata. This PR removes those defaulted and potentially incorrect values.

This should resolve #4. Also, see #6, #7 , #8, for capturing the intended enhancements.