### PR TITLE
Cargo.toml tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 authors = ["Jamie Blondin <jblondin@gmail.com>"]
 description = "A CSV file format sniffer for Rust"
 exclude = ["tests/data/*"]
-license-file = "LICENSE"
+keywords = ["csv"]
+categories = ["parser-implementations"]
+license = "MIT"
 name = "csv-sniffer"
 repository = "https://github.com/jblondin/csv-sniffer"
 version = "0.3.0"


### PR DESCRIPTION
Hope you don't mind @jblondin 😉 

- as license shows up as "non-standard" in crates.io
- keywords and categories to help with discoverability