### PR TITLE
Add non-utf8-support

### DIFF
--- a/src/sample.rs
+++ b/src/sample.rs
@@ -50,8 +50,8 @@ impl<'a, R: Read> Iterator for SampleIter<'a, R> {
             return None;
         }
 
-        let mut output = String::new();
-        let n_bytes_read = match self.reader.read_line(&mut output) {
+        let mut buf = vec![];
+        let n_bytes_read = match self.reader.read_until(b'\n', &mut buf) {
             Ok(n_bytes_read) => n_bytes_read,
             Err(e) => {
                 return Some(Err(e.into()));
@@ -61,6 +61,7 @@ impl<'a, R: Read> Iterator for SampleIter<'a, R> {
             self.is_done = true;
             return None;
         }
+        let mut output = String::from_utf8_lossy(&buf).to_string();
         let last_byte = (output.as_ref() as &[u8])[output.len() - 1];
         if last_byte != b'\n' && last_byte != b'\r' {
             // non CR/LF-ended line

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -8,7 +8,7 @@ use csv_core as csvc;
 use regex::Regex;
 
 use crate::{
-    chain::{Chain, ViterbiResults, STATE_UNSTEADY},
+    chain::{Chain, ViterbiResults, STATE_UNSTEADY, STATE_STEADYSTRICT, STATE_STEADYFLEX},
     error::{Result, SnifferError},
     field_type::{get_best_types, infer_record_types, infer_types, Type, TypeGuesses},
     metadata::{Dialect, Header, Metadata, Quote},
@@ -326,7 +326,7 @@ impl Sniffer {
         let field_count = self.delimiter_freq.unwrap() + 1;
 
         let mut csv_reader = self.create_csv_reader(reader)?;
-        let mut records_iter = csv_reader.records();
+        let mut records_iter = csv_reader.byte_records();
         let mut n_bytes = 0;
         let mut n_records = 0;
         let sample_size = self.get_sample_size();
@@ -335,10 +335,11 @@ impl Sniffer {
         // of the remaining rows to see if this is part of the data or a separate header row.
         let header_row_types = match records_iter.next() {
             Some(record) => {
-                let record = record?;
+                let byte_record = record?;
+                let str_record = StringRecord::from_byte_record_lossy(byte_record);
                 n_records += 1;
-                n_bytes += count_bytes(&record);
-                infer_record_types(&record)
+                n_bytes += count_bytes(&str_record);
+                infer_record_types(&str_record)
             }
             None => {
                 return Err(SnifferError::SniffingFailed(
@@ -351,10 +352,11 @@ impl Sniffer {
         for record in records_iter {
             let record = record?;
             for (i, field) in record.iter().enumerate() {
-                row_types[i] &= infer_types(field);
+                let str_field = String::from_utf8_lossy(field).to_string();
+                row_types[i] &= infer_types(&str_field);
             }
             n_records += 1;
-            n_bytes += count_bytes(&record);
+            n_bytes += record.as_slice().len();
             // break if we pass sample size limits
             match sample_size {
                 SampleSize::Records(recs) => {


### PR DESCRIPTION
- by using byterecords
- by using `read_until` instead of `read_line` in sample.rs
- also corrected flexible not working because the consts STATE_STEADYSTRICT and STATE_STEADYFLEX were not imported from chain.rs

resolves #13 